### PR TITLE
Enabled persistant connection

### DIFF
--- a/source/connectionBase/connectionBase.cpp
+++ b/source/connectionBase/connectionBase.cpp
@@ -24,3 +24,14 @@ void kleins::connectionBase::join() {
     }
   }
 }
+
+void kleins::connectionBase::setTimeout(unsigned int timeoutin) { timeout = timeoutin; }
+
+void kleins::connectionBase::resetTimeoutTimer() { lastPacket = std::chrono::steady_clock::now(); }
+
+bool kleins::connectionBase::getTimeout() {
+  if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - lastPacket).count() > timeout) {
+    return true;
+  }
+  return false;
+}

--- a/source/connectionBase/connectionBase.h
+++ b/source/connectionBase/connectionBase.h
@@ -1,6 +1,7 @@
 #ifndef CONNECTIONBASE_H
 #define CONNECTIONBASE_H
 
+#include <chrono>
 #include <future>
 #include <iostream>
 #include <list>
@@ -15,6 +16,9 @@ class connectionBase {
 private:
   static void ownTickLoop(connectionBase* conn);
   std::thread* tickThread = 0;
+  unsigned int timeout = 30000;
+
+  std::chrono::time_point<std::chrono::steady_clock> lastPacket;
 
 public:
   connectionBase();
@@ -31,6 +35,11 @@ public:
   virtual void close_socket() = 0;
 
   void join();
+
+  void setTimeout(unsigned int timeoutInMS = 30000);
+
+  void resetTimeoutTimer();
+  bool getTimeout();
 
   std::function<void(std::unique_ptr<packet>)> onRecieveCallback;
 };

--- a/source/httpParser/httpParser.cpp
+++ b/source/httpParser/httpParser.cpp
@@ -104,6 +104,10 @@ void kleins::httpParser::respond(
     response << *it << "\r\n";
   }
 
+  if (headers["Connection"] == "keep-alive") {
+    response << "Keep-Alive: timeout=30\r\n";
+  }
+
   response << "content-length: " << body.size() + 2 << "\r\n";
   response << "Content-Type: " << mimeType << "; charset=utf-8"
            << "\r\n";

--- a/source/httpServer/httpServer.cpp
+++ b/source/httpServer/httpServer.cpp
@@ -123,7 +123,9 @@ void kleins::httpServer::newConnection(kleins::connectionBase* conn) {
 
     parser.get()->parse();
 
-    conn->close_socket();
+    if (parser->headers["Connection"] != "keep-alive") {
+      conn->close_socket();
+    }
   };
 
   if (conn->onRecieveCallback) {

--- a/source/sslConnection/sslConnection.cpp
+++ b/source/sslConnection/sslConnection.cpp
@@ -9,6 +9,7 @@ kleins::sslConnection::sslConnection(int connectionid, SSL_CTX* sslcontext) {
     ERR_print_errors_fp(stderr);
     initOk = false;
   }
+  resetTimeoutTimer();
 }
 
 kleins::sslConnection::~sslConnection() {
@@ -37,8 +38,15 @@ void kleins::sslConnection::tick() {
   if (!packetBuffer->size) {
     usleep(20000);
     delete packetBuffer;
+
+    if (getTimeout()) {
+      close_socket();
+    }
+
     return;
   }
+
+  resetTimeoutTimer();
 
   packetBuffer->data.resize(packetBuffer->size);
 

--- a/source/tcpConnection/tcpConnection.cpp
+++ b/source/tcpConnection/tcpConnection.cpp
@@ -1,6 +1,9 @@
 #include "tcpConnection.h"
 
-kleins::tcpConnection::tcpConnection(int connectionid) { connectionfd = connectionid; }
+kleins::tcpConnection::tcpConnection(int connectionid) {
+  connectionfd = connectionid;
+  resetTimeoutTimer();
+}
 
 kleins::tcpConnection::~tcpConnection() {
   close_socket();
@@ -24,8 +27,15 @@ void kleins::tcpConnection::tick() {
   if (packetBuffer->size == -1) {
     delete packetBuffer;
     usleep(20000);
+
+    if (getTimeout()) {
+      close_socket();
+    }
+
     return;
   }
+
+  resetTimeoutTimer();
 
   packetBuffer->data.resize(packetBuffer->size);
 


### PR DESCRIPTION
Enabled persistent connection.
This allows browsers to just open one tcp connection and request everything over that.